### PR TITLE
Implement %g format for printf and use this format by default

### DIFF
--- a/config.c
+++ b/config.c
@@ -274,6 +274,7 @@ STATIC NAMETYPE modes[] = {
 	{"oct",		MODE_OCTAL},
 	{"binary",	MODE_BINARY},
 	{"bin",		MODE_BINARY},
+	{"float-auto",	MODE_REAL_AUTO},
 	{"off",		MODE2_OFF},
 	{NULL,		0}
 };

--- a/file.c
+++ b/file.c
@@ -1027,6 +1027,9 @@ idprintf(FILEID id, char *fmt, int count, VALUE **vals)
 		case 'e':
 			newmode = MODE_EXP;
 			break;
+		case 'g':
+			newmode = MODE_REAL_AUTO;
+			break;
 		case 'r':
 			newmode = MODE_FRAC;
 			break;

--- a/qio.c
+++ b/qio.c
@@ -233,6 +233,27 @@ qprintnum(NUMBER *q, int outmode)
 		PRINTF1("e%ld", exp);
 		break;
 
+	case MODE_REAL_AUTO:
+	{
+		const int P = conf->outdigits ? conf->outdigits : 1;
+		tmpval = *q;
+		tmpval.num.sign = 0;
+		exp = qilog10(&tmpval);
+		const long olddigits = conf->outdigits;
+		if(P > exp && exp >= -4)
+		{
+			conf->outdigits = P - 1 - exp;
+			qprintnum(q, MODE_REAL);
+		}
+		else
+		{
+			conf->outdigits = P - 1;
+			qprintnum(q, MODE_EXP);
+		}
+		conf->outdigits = olddigits;
+		break;
+	}
+
 	case MODE_HEX:
 		qprintfx(q, 0L);
 		break;

--- a/zmath.h
+++ b/zmath.h
@@ -583,7 +583,7 @@ E_FUNC void zredcpower(REDC *rp, ZVALUE z1, ZVALUE z2, ZVALUE *res);
 #define MODE_MAX	8
 #define MODE2_OFF	(MODE_MAX+1)
 
-#define MODE_INITIAL	MODE_REAL
+#define MODE_INITIAL	MODE_REAL_AUTO
 #define MODE2_INITIAL	MODE2_OFF
 
 

--- a/zmath.h
+++ b/zmath.h
@@ -579,7 +579,8 @@ E_FUNC void zredcpower(REDC *rp, ZVALUE z1, ZVALUE z2, ZVALUE *res);
 #define MODE_HEX	5
 #define MODE_OCTAL	6
 #define MODE_BINARY	7
-#define MODE_MAX	7
+#define MODE_REAL_AUTO	8
+#define MODE_MAX	8
 #define MODE2_OFF	(MODE_MAX+1)
 
 #define MODE_INITIAL	MODE_REAL


### PR DESCRIPTION
ANSI C supports, aside from `%e` and `%f`, the `%g` format specifier for `printf` (see e,g, description at [cppreference](https://en.cppreference.com/w/c/io/fprintf)). This is much more human-friendly way of outputting numbers: e.g. if you printf a number like `1.235e-53` in the `%f` format, you'll get `0.000...00`. OTOH, `%g` will give you `1.235e-53`.

The first patch here implements support for this format (it's simply the logic of choosing `%e` vs `%f` format and precision depending on exponent of the number and precision requested). The second patch makes this the default format of number output.