### PR TITLE
Fix compilation with GCC 7+

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -1021,7 +1021,7 @@ getstatement(LABEL *contlabel, LABEL *breaklabel,
 			return;
 		}
 		reread();
-		/* fall into default case */
+        /* fall through */
 
 	default:
 		rescantoken();
@@ -1384,6 +1384,7 @@ creatematrix(void)
 		switch (gettoken()) {
 		case T_RIGHTBRACKET:
 			rescantoken();
+            /* fall through */
 		case T_COMMA:
 			addop(OP_ONE);
 			addop(OP_SUB);
@@ -1394,6 +1395,7 @@ creatematrix(void)
 			switch(gettoken()) {
 			case T_RIGHTBRACKET:
 				rescantoken();
+                /* fall through */
 			case T_COMMA:
 				continue;
 			}
@@ -2211,6 +2213,7 @@ getterm(void)
 				scanerror(T_NULL,
 					  "Function calls not allowed "
 					  "as expressions");
+                /* fall through */
 			default:
 				rescantoken();
 			return type;
@@ -2248,7 +2251,7 @@ getidexpr(BOOL okmat, int autodef)
 		if (autodef != T_GLOBAL && autodef != T_LOCAL &&
 				autodef != T_STATIC)
 			autodef = 1;
-		/* fall into default case */
+        /* fall through */
 	default:
 		rescantoken();
 		usesymbol(name, autodef);
@@ -2277,6 +2280,7 @@ getidexpr(BOOL okmat, int autodef)
 			scanerror(T_NULL,
 				  "Function calls not allowed "
 				  "as expressions");
+        /* fall through */
 		default:
 			rescantoken();
 			return type;

--- a/codegen.c
+++ b/codegen.c
@@ -1021,7 +1021,7 @@ getstatement(LABEL *contlabel, LABEL *breaklabel,
 			return;
 		}
 		reread();
-        /* fall through */
+		/*FALLTHRU*/
 
 	default:
 		rescantoken();
@@ -1384,7 +1384,7 @@ creatematrix(void)
 		switch (gettoken()) {
 		case T_RIGHTBRACKET:
 			rescantoken();
-            /* fall through */
+			/*FALLTHRU*/
 		case T_COMMA:
 			addop(OP_ONE);
 			addop(OP_SUB);
@@ -1395,7 +1395,7 @@ creatematrix(void)
 			switch(gettoken()) {
 			case T_RIGHTBRACKET:
 				rescantoken();
-                /* fall through */
+				/*FALLTHRU*/
 			case T_COMMA:
 				continue;
 			}
@@ -2213,7 +2213,7 @@ getterm(void)
 				scanerror(T_NULL,
 					  "Function calls not allowed "
 					  "as expressions");
-                /* fall through */
+				/*FALLTHRU*/
 			default:
 				rescantoken();
 			return type;
@@ -2251,7 +2251,7 @@ getidexpr(BOOL okmat, int autodef)
 		if (autodef != T_GLOBAL && autodef != T_LOCAL &&
 				autodef != T_STATIC)
 			autodef = 1;
-        /* fall through */
+		/*FALLTHRU*/
 	default:
 		rescantoken();
 		usesymbol(name, autodef);
@@ -2280,7 +2280,7 @@ getidexpr(BOOL okmat, int autodef)
 			scanerror(T_NULL,
 				  "Function calls not allowed "
 				  "as expressions");
-        /* fall through */
+			/*FALLTHRU*/
 		default:
 			rescantoken();
 			return type;

--- a/config.c
+++ b/config.c
@@ -909,42 +909,42 @@ setconfig(int type, VALUE *vp)
 	case CONFIG_PROGRAM:
 		math_error("The program config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_BASENAME:
 		math_error("The basename config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_WINDOWS:
 		math_error("The windows config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_CYGWIN:
 		math_error("The cygwin config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_COMPILE_CUSTOM:
 		math_error("The custom config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_ALLOW_CUSTOM:
 		math_error("The allow_custom config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_VERSION:
 		math_error("The version config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_BASEB:
 		math_error("The baseb config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	case CONFIG_REDECL_WARN:
 		if (vp->v_type == V_NUM) {
@@ -979,12 +979,12 @@ setconfig(int type, VALUE *vp)
 	case CONFIG_HZ:
 		math_error("The clock tick rate config parameter is read-only");
 		/*NOTREACHED*/
-        abort();
+		abort();
 
 	default:
 		math_error("Setting illegal config parameter");
 		/*NOTREACHED*/
-        abort();
+		abort();
 	}
 }
 

--- a/config.c
+++ b/config.c
@@ -909,34 +909,42 @@ setconfig(int type, VALUE *vp)
 	case CONFIG_PROGRAM:
 		math_error("The program config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_BASENAME:
 		math_error("The basename config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_WINDOWS:
 		math_error("The windows config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_CYGWIN:
 		math_error("The cygwin config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_COMPILE_CUSTOM:
 		math_error("The custom config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_ALLOW_CUSTOM:
 		math_error("The allow_custom config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_VERSION:
 		math_error("The version config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_BASEB:
 		math_error("The baseb config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	case CONFIG_REDECL_WARN:
 		if (vp->v_type == V_NUM) {
@@ -971,10 +979,12 @@ setconfig(int type, VALUE *vp)
 	case CONFIG_HZ:
 		math_error("The clock tick rate config parameter is read-only");
 		/*NOTREACHED*/
+        abort();
 
 	default:
 		math_error("Setting illegal config parameter");
 		/*NOTREACHED*/
+        abort();
 	}
 }
 

--- a/file.c
+++ b/file.c
@@ -1021,7 +1021,7 @@ idprintf(FILEID id, char *fmt, int count, VALUE **vals)
 		switch (ch) {
 		case 's':
 			printstring = TRUE;
-            /* fall through */
+			/*FALLTHRU*/
 		case 'c':
 			printchar = TRUE;
 		case 'd':

--- a/file.c
+++ b/file.c
@@ -1021,6 +1021,7 @@ idprintf(FILEID id, char *fmt, int count, VALUE **vals)
 		switch (ch) {
 		case 's':
 			printstring = TRUE;
+            /* fall through */
 		case 'c':
 			printchar = TRUE;
 		case 'd':

--- a/opcodes.c
+++ b/opcodes.c
@@ -4106,7 +4106,7 @@ freenumbers(FUNC *fp)
 				    (long)fp->f_opcodes[pc]);
 				break;
 			}
-			/* FALLTHRU */
+			/*FALLTHRU*/
 		case OPLOC:
 		case OPPAR:
 		case OPJMP:

--- a/opcodes.c
+++ b/opcodes.c
@@ -4104,8 +4104,9 @@ freenumbers(FUNC *fp)
 			case OP_QUIT:
 				freestringconstant(
 				    (long)fp->f_opcodes[pc]);
+                break;
 			}
-			/*FALLTHRU*/
+			/* FALLTHRU */
 		case OPLOC:
 		case OPPAR:
 		case OPJMP:

--- a/opcodes.c
+++ b/opcodes.c
@@ -4104,7 +4104,7 @@ freenumbers(FUNC *fp)
 			case OP_QUIT:
 				freestringconstant(
 				    (long)fp->f_opcodes[pc]);
-                break;
+				break;
 			}
 			/* FALLTHRU */
 		case OPLOC:

--- a/qio.c
+++ b/qio.c
@@ -144,6 +144,7 @@ qprintf(char *fmt, ...)
 		case '-':
 			sign = -1;
 			ch = *fmt++;
+            /* fall through */
 		default:
 			if (('0' <= ch && ch <= '9') ||
 			    ch == '.' || ch == '*') {

--- a/qio.c
+++ b/qio.c
@@ -144,7 +144,7 @@ qprintf(char *fmt, ...)
 		case '-':
 			sign = -1;
 			ch = *fmt++;
-            /* fall through */
+			/*FALLTHRU*/
 		default:
 			if (('0' <= ch && ch <= '9') ||
 			    ch == '.' || ch == '*') {

--- a/token.c
+++ b/token.c
@@ -447,6 +447,7 @@ eatstring(int quotechar)
 		case '\n':
 			if (!newlines)
 				break;
+            /* fall through */
 		case EOF:
 			reread();
 			scanerror(T_NULL,

--- a/token.c
+++ b/token.c
@@ -447,7 +447,7 @@ eatstring(int quotechar)
 		case '\n':
 			if (!newlines)
 				break;
-            /* fall through */
+			/*FALLTHRU*/
 		case EOF:
 			reread();
 			scanerror(T_NULL,


### PR DESCRIPTION
GCC 7 added a warning on fall throughs in case statements.
It's enabled by -Wextra and treated as an error due to -Wall so it breaks compilation.

See -Wimplicit-fallthrough in the GCC manual.

The default value is 3, which means a comment matching some specific regexes is enough to disable the warning.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
