### PR TITLE
Avoid implicit declaration memset in have_fpos_pos.c probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3226,7 +3226,7 @@ have_fgetsetpos.h: have_fgetsetpos.c banned.h have_ban_pragma.h ${MAKE_FILE} ${L
 	    ${TRUE}; \
 	fi
 
-have_fpos_pos.h: have_fpos_pos.c have_fgetsetpos.h have_posscl.h \
+have_fpos_pos.h: have_fpos_pos.c have_fgetsetpos.h have_posscl.h have_string.h \
 		 banned.h have_ban_pragma.h ${MAKE_FILE} ${LOC_MKF}
 	${Q} ${RM} -f fpos_tmp $@
 	${H} echo 'forming $@'

--- a/Makefile.simple
+++ b/Makefile.simple
@@ -2540,7 +2540,7 @@ have_fgetsetpos.h: have_fgetsetpos.c banned.h have_ban_pragma.h ${MAKE_FILE} ${L
 	    ${TRUE}; \
 	fi
 
-have_fpos_pos.h: have_fpos_pos.c have_fgetsetpos.h have_posscl.h \
+have_fpos_pos.h: have_fpos_pos.c have_fgetsetpos.h have_posscl.h have_string.h \
 		 banned.h have_ban_pragma.h ${MAKE_FILE} ${LOC_MKF}
 	${Q} ${RM} -f fpos_tmp $@
 	${H} echo 'forming $@'

--- a/have_fpos_pos.c
+++ b/have_fpos_pos.c
@@ -28,6 +28,10 @@
 #include <stdio.h>
 #include "have_fgetsetpos.h"
 #include "have_posscl.h"
+#include "have_string.h"
+#ifdef HAVE_STRING_H
+# include <string.h>
+#endif
 
 
 #include "banned.h"	/* include after system header <> includes */


### PR DESCRIPTION
Otherwise, the probe result changes with compilers which do not support implicit function declarations, a language feature that was removed from C in 1999.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
