### PR TITLE
Fix file.c build failure on 32 bit big endian machines

### DIFF
--- a/fposval.c
+++ b/fposval.c
@@ -114,15 +114,20 @@ main(int UNUSED(argc), char **argv)
 	/*
 	 * Big Endian
 	 */
+	/*
+	 * Use casts to (HALF *) because SWAP_HALF_IN_B* might expand to
+	 * a simple assignment and SWAP_HALF_IN_FILEPOS might get a
+	 * (HALF *) and a (FILEPOS *) which are not assignment-compatible.
+	 */
 	if (fileposlen == 64) {
 		printf("#define SWAP_HALF_IN_FILEPOS(dest, src) \\\n"
-		       "\tSWAP_HALF_IN_B64(dest, src)\n");
+		       "\tSWAP_HALF_IN_B64((HALF *)dest, (HALF *)src)\n");
 	} else if (fileposlen == 32) {
 		printf("#define SWAP_HALF_IN_FILEPOS(dest, src) \\\n"
-		       "\tSWAP_HALF_IN_B32(dest, src)\n");
+		       "\tSWAP_HALF_IN_B32((HALF *)dest, (HALF *)src)\n");
 	} else if (fileposlen%BASEB == 0) {
 		printf("#define SWAP_HALF_IN_FILEPOS(dest, src) \\\n"
-		       "\tswap_HALFs(dest, src, %d)\n",
+		       "\tswap_HALFs((HALF *)dest, (HALF *)src, %d)\n",
 		       fileposlen/BASEB);
 	} else {
 		fprintf(stderr, "%s: unexpected BIG_ENDIAN FILEPOS bit size: %d\n",


### PR DESCRIPTION
On ancient 32 bit big endian machines (e.g. MIPS) file.c fails to build when FILEPOS is a struct and not a scalar. This happens because the SWAP_HALF_IN_FILEPOS macro essentially expands to a simple assignment in this case but the types are incompatile (HALF and FILEPOS).

Detailed compile error (this is from an older version so line numbers might be wrong but the error is the same):

gcc  -DCALC_SRC -DCUSTOM -Wall  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security   -O3 -g3 -Wno-error=long-long -Wno-long-long -c file.c
In file included from qmath.h:32,
                 from cmath.h:32,
                 from value.h:33,
                 from calc.h:33,
                 from file.c:39:
file.c: In function 'filepos2z':
zmath.h:85:46: error: incompatible types when assigning to type 'HALF' {aka 'long unsigned int'} from type 'FILEPOS' {aka 'struct _G_fpos_t'}
 #define SWAP_HALF_IN_B32(dest, src) (*(dest) = *(src))
                                              ^
fposval.h:15:42: note: in expansion of macro 'SWAP_HALF_IN_B32'
 #define SWAP_HALF_IN_FILEPOS(dest, src)  SWAP_HALF_IN_B32(dest, src)
                                          ^~~~~~~~~~~~~~~~
file.c:1370:2: note: in expansion of macro 'SWAP_HALF_IN_FILEPOS'
  SWAP_HALF_IN_FILEPOS(ret.v, &pos);
  ^~~~~~~~~~~~~~~~~~~~

Fix this by adding suitable casts to the definition of SWAP_HALF_IN_FILEPOS on big endian machines. Strictly speaking, the casts only seem to be necessary when using SWAP_HALF_IN_B32, but they can't hurt in the other cases either.