### PR TITLE
Actually check for sys/mount.h when forming have_sys_mount.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1824,7 +1824,7 @@ have_sys_mount.h: ${MK_SET}
 	    echo '#define HAVE_SYS_MOUNT_H	/* yes */' >> $@; \
 	elif [ X"${HAVE_SYS_MOUNT_H}" = X"NO" ]; then \
 	    echo '#undef HAVE_SYS_MOUNT_H  /* no */' >> $@; \
-	elif echo '#include <sys/param.h>' | ${CC} -E - ${S}; then \
+	elif echo '#include <sys/mount.h>' | ${CC} -E - ${S}; then \
 	    echo '#define HAVE_SYS_MOUNT_H	 /* yes */' >> $@; \
 	else \
 	    echo '#undef HAVE_SYS_MOUNT_H	/* no */' >> $@; \


### PR DESCRIPTION
So far, the Makefile checked for sys/param.h instead and that suspiciously looks like a copy & paste error.

Found by the Debian hurd-i386 build daemon because calc failed to compile there and it seems to lack sys/mount.h. Not that this would be an extremely relevant architecture these days, but nevertheless... ;-)