### PR TITLE
Fix memory leak in zrandom.c

### DIFF
--- a/zrandom.c
+++ b/zrandom.c
@@ -2679,6 +2679,9 @@ zsetrandom(CONST RANDOM *state)
 	 */
 	if (state != NULL) {
 		p_blum = randomcopy(state);
+		if (blum_initialized == true) {
+			randomfree(&blum);
+		}
 		blum = *p_blum;
 		free(p_blum);
 	}


### PR DESCRIPTION
Hello, I am a new contributor to the repository.

I tried to fix following issue: #47   Memory leak on `make clobber all chk`. I was able to reproduce the following leaks which are slightly different from the ones above:

```
=================================================================
==965935==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fc0559f1808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fc05520ee6e in alloc /home/aniruddhan/Downloads/calc/zmath.c:242
    #2 0x7fc055217b76 in zdiv /home/aniruddhan/Downloads/calc/zmath.c:1008
    #3 0x7fc05521870f in zmod /home/aniruddhan/Downloads/calc/zmath.c:1069
    #4 0x7fc055225a2c in zsquaremod /home/aniruddhan/Downloads/calc/zmod.c:122
    #5 0x7fc055271be0 in zsrandom1 /home/aniruddhan/Downloads/calc/zrandom.c:2337
    #6 0x7fc054fececf in f_srandom /home/aniruddhan/Downloads/calc/func.c:1320
    #7 0x7fc055080f32 in builtinfunc /home/aniruddhan/Downloads/calc/func.c:13433
    #8 0x7fc0550eb6dd in o_call /home/aniruddhan/Downloads/calc/opcodes.c:2725
    #9 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #10 0x7fc0550eb628 in o_usercall /home/aniruddhan/Downloads/calc/opcodes.c:2716
    #11 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #12 0x7fc054f738aa in evaluate /home/aniruddhan/Downloads/calc/codegen.c:300
    #13 0x7fc054f7349d in getcommands /home/aniruddhan/Downloads/calc/codegen.c:230
    #14 0x7fc054f7336e in getcommands /home/aniruddhan/Downloads/calc/codegen.c:187
    #15 0x559b1cca636e in main /home/aniruddhan/Downloads/calc/calc.c:669
    #16 0x7fc053eab082 in __libc_start_main ../csu/libc-start.c:308

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fc0559f1808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fc05520ee6e in alloc /home/aniruddhan/Downloads/calc/zmath.c:242
    #2 0x7fc055217b76 in zdiv /home/aniruddhan/Downloads/calc/zmath.c:1008
    #3 0x7fc05521870f in zmod /home/aniruddhan/Downloads/calc/zmath.c:1069
    #4 0x7fc055225a2c in zsquaremod /home/aniruddhan/Downloads/calc/zmod.c:122
    #5 0x7fc0552750ff in zrandom /home/aniruddhan/Downloads/calc/zrandom.c:2951
    #6 0x7fc054feb1ae in f_random /home/aniruddhan/Downloads/calc/func.c:1207
    #7 0x7fc055081556 in builtinfunc /home/aniruddhan/Downloads/calc/func.c:13452
    #8 0x7fc0550eb6dd in o_call /home/aniruddhan/Downloads/calc/opcodes.c:2725
    #9 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #10 0x7fc0550eb628 in o_usercall /home/aniruddhan/Downloads/calc/opcodes.c:2716
    #11 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #12 0x7fc054f738aa in evaluate /home/aniruddhan/Downloads/calc/codegen.c:300
    #13 0x7fc054f7349d in getcommands /home/aniruddhan/Downloads/calc/codegen.c:230
    #14 0x7fc054f7336e in getcommands /home/aniruddhan/Downloads/calc/codegen.c:187
    #15 0x559b1cca636e in main /home/aniruddhan/Downloads/calc/calc.c:669
    #16 0x7fc053eab082 in __libc_start_main ../csu/libc-start.c:308

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fc0559f1808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fc05520ee6e in alloc /home/aniruddhan/Downloads/calc/zmath.c:242
    #2 0x7fc055217b76 in zdiv /home/aniruddhan/Downloads/calc/zmath.c:1008
    #3 0x7fc05521870f in zmod /home/aniruddhan/Downloads/calc/zmath.c:1069
    #4 0x7fc055225a2c in zsquaremod /home/aniruddhan/Downloads/calc/zmod.c:122
    #5 0x7fc0552750ff in zrandom /home/aniruddhan/Downloads/calc/zrandom.c:2951
    #6 0x7fc055275961 in zrandomrange /home/aniruddhan/Downloads/calc/zrandom.c:3034
    #7 0x7fc054febc71 in f_random /home/aniruddhan/Downloads/calc/func.c:1230
    #8 0x7fc055081556 in builtinfunc /home/aniruddhan/Downloads/calc/func.c:13452
    #9 0x7fc0550eb6dd in o_call /home/aniruddhan/Downloads/calc/opcodes.c:2725
    #10 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #11 0x7fc0550eb628 in o_usercall /home/aniruddhan/Downloads/calc/opcodes.c:2716
    #12 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #13 0x7fc054f738aa in evaluate /home/aniruddhan/Downloads/calc/codegen.c:300
    #14 0x7fc054f7349d in getcommands /home/aniruddhan/Downloads/calc/codegen.c:230
    #15 0x7fc054f7336e in getcommands /home/aniruddhan/Downloads/calc/codegen.c:187
    #16 0x559b1cca636e in main /home/aniruddhan/Downloads/calc/calc.c:669
    #17 0x7fc053eab082 in __libc_start_main ../csu/libc-start.c:308

Direct leak of 36 byte(s) in 1 object(s) allocated from:
    #0 0x7fc0559f1808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7fc05520ee6e in alloc /home/aniruddhan/Downloads/calc/zmath.c:242
    #2 0x7fc055217b76 in zdiv /home/aniruddhan/Downloads/calc/zmath.c:1008
    #3 0x7fc05521870f in zmod /home/aniruddhan/Downloads/calc/zmath.c:1069
    #4 0x7fc055225a2c in zsquaremod /home/aniruddhan/Downloads/calc/zmod.c:122
    #5 0x7fc0552750ff in zrandom /home/aniruddhan/Downloads/calc/zrandom.c:2951
    #6 0x7fc054febdfc in f_randombit /home/aniruddhan/Downloads/calc/func.c:1256
    #7 0x7fc055081556 in builtinfunc /home/aniruddhan/Downloads/calc/func.c:13452
    #8 0x7fc0550eb6dd in o_call /home/aniruddhan/Downloads/calc/opcodes.c:2725
    #9 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #10 0x7fc0550eb628 in o_usercall /home/aniruddhan/Downloads/calc/opcodes.c:2716
    #11 0x7fc0550f5b10 in calculate /home/aniruddhan/Downloads/calc/opcodes.c:4179
    #12 0x7fc054f738aa in evaluate /home/aniruddhan/Downloads/calc/codegen.c:300
    #13 0x7fc054f7349d in getcommands /home/aniruddhan/Downloads/calc/codegen.c:230
    #14 0x7fc054f7336e in getcommands /home/aniruddhan/Downloads/calc/codegen.c:187
    #15 0x559b1cca636e in main /home/aniruddhan/Downloads/calc/calc.c:669
    #16 0x7fc053eab082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 156 byte(s) leaked in 4 allocation(s).
```


The leak occurs in function `zsetrandom` where `blum` is reassigned before freeing. In fact just above the fix lies another patch of code that frees `blum` before assigning it. Therefore the patch frees `blum` before it is reassigned.

After this, the leaks are patched. I was able to verify that the leaks are gone and there is no double free.
Let me know if the patch is helpful :)

