### PR TITLE
Add includes to alloc.h for CONST and E_FUNC

### DIFF
--- a/alloc.h
+++ b/alloc.h
@@ -29,13 +29,17 @@
 
 
 #if defined(CALC_SRC)   /* if we are building from the calc source tree */
+# include "decl.h"
 # include "have_newstr.h"
 # include "have_string.h"
 # include "have_memmv.h"
+# include "have_const.h"
 #else
+# include <calc/decl.h>
 # include <calc/have_newstr.h>
 # include <calc/have_string.h>
 # include <calc/have_memmv.h>
+# include <calc/have_const.h>
 #endif
 
 #ifdef HAVE_STRING_H


### PR DESCRIPTION
These are required for the `#undef HAVE_NEWSTR` and `#undef HAVE_MEMMOVE` configurations, both of which have been broken since c773ee736f24bad2a2274bbc08149f399303e2c4 (18 years ago).