### PR TITLE
fixed reversed calloc argument order, now (count, size)

### DIFF
--- a/const.c
+++ b/const.c
@@ -45,7 +45,7 @@ initconstants(void)
 {
         int i;
 
-        consttable = (NUMBER **) calloc(sizeof(NUMBER *), CONSTALLOCSIZE);
+        consttable = (NUMBER **) calloc(CONSTALLOCSIZE, sizeof(NUMBER *));
         if (consttable == NULL) {
                 math_error("Unable to allocate constant table");
                 not_reached();


### PR DESCRIPTION
Fixes compiler warning with GCC 14.x or newer.

gcc  -DCALC_SRC -DCUSTOM -Wall -Wextra -pedantic     -UUNBAN -fPIC -O3 -g3   -c -o const.o const.c
const.c: In function 'initconstants':
const.c:48:48: warning: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
   48 |         consttable = (NUMBER **) calloc(sizeof(NUMBER *), CONSTALLOCSIZE);
      |                                                ^~~~~~
const.c:48:48: note: earlier argument should specify number of elements, later size of each element

Also fixes potential memory alignment issues. 