### PR TITLE
fixed missing man path option in comment

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -55,6 +55,7 @@
 # PREFIX:= /usr/local
 # BINDIR:= ${PREFIX}/bin
 # LIBDIR:= ${PREFIX}/lib
+# MANDIR:= ${PREFIX}/share/man/man1
 # CALC_SHAREDIR:= ${PREFIX}/share/calc
 # CALC_INCDIR:= ${PREFIX}/include/calc
 ####


### PR DESCRIPTION
This avoids installing man pages in system areas when everything else is installed in whatever PREFIX is set to.