### PR TITLE
For Cygwin disable a gcc warning.

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -328,7 +328,7 @@ LD_STATIC=
 # common values set for this target
 #
 #CCWARN= -Wall
-CCWARN= -Wall -Wextra -pedantic
+CCWARN= -Wall -Wextra -pedantic -Wno-char-subscripts
 WNO_IMPLICT= -Wno-implicit
 WNO_ERROR_LONG_LONG= -Wno-error=long-long
 WNO_LONG_LONG= -Wno-long-long


### PR DESCRIPTION
Per your Discord questions, list of Cygwin gcc predefines.

[typescript.txt](https://github.com/user-attachments/files/24777169/typescript.txt)
