### PR TITLE
Describe self-service XDG base dir. spec. adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,33 @@ help unexpected
 ```
 
 It contains information about differences between C and calc
-that may surprise C programmers.
+that may surprise C programmers.  The command:
 
+```sh
+help environment
+```
+
+contains information regarding how environment variables
+can be used to configure some aspects of calc.  In versions
+prior to v3, you may adhere to the [XDG Base Directory
+specification](https://specifications.freedesktop.org/basedir/latest/)
+by setting up your environment variables as such:
+
+```sh
+export CALCRC="${XDG_CONFIG_HOME:-$HOME/.config}/calc/calcrc"
+export CALCPATH=".:${XDG_DATA_HOME:-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
+export CALCHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/calc/history"
+```
+
+Note that calc won't create the directory tree to `$CALCHISTFILE`,
+you'll need to run:
+
+```sh
+mkdir -p $(dirname $CALCHISTFILE)
+```
+
+in order to have the history mechanism if you choose a path to a file
+that doesn't exist.
 
 # Reporting Security Issues
 

--- a/calc.man
+++ b/calc.man
@@ -1255,6 +1255,32 @@ Default value: ${CUSTOMHELPDIR}
 
 .PP
 
+In versions prior to v3, you may adhere to the XDG Base Directory
+specification by setting up your environment variables as such:
+.sp
+.in +5n
+.nf
+export CALCRC="${XDG_CONFIG_HOME:\-$HOME/.config}/calc/calcrc"
+export CALCPATH=".:${XDG_DATA_HOME:\-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:\-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
+export CALCHISTFILE="${XDG_STATE_HOME:\-$HOME/.local/state}/calc/history"
+.fi
+.in -5n
+.sp
+Note that
+.B calc
+won't create the directory tree to $CALCHISTFILE,
+you'll need to run:
+.sp
+.in +5n
+.nf
+mkdir \-p $(dirname $CALCHISTFILE)
+.fi
+.in -5n
+.sp
+in order to have the history mechanism if you choose a path to a file
+that doesn't exist.
+.sp
+
 .SH CREDIT
 
 .PP

--- a/help/environment
+++ b/help/environment
@@ -116,6 +116,21 @@ Environment variables
         variable is an empty string, then ${CUSTOMHELPDIR}
         is used.
 
+In versions prior to v3, you may adhere to the XDG Base Directory
+specification by setting up your environment variables as such:
+
+        export CALCRC="${XDG_CONFIG_HOME:-$HOME/.config}/calc/calcrc"
+        export CALCPATH=".:${XDG_DATA_HOME:-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
+        export CALCHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/calc/history"
+
+Note that calc won't create the directory tree to $CALCHISTFILE,
+you'll need to run:
+
+        mkdir -p $(dirname $CALCHISTFILE)
+
+in order to have the history mechanism if you choose a path to a file
+that doesn't exist.
+
 ## Copyright (C) 1999,2021  Landon Curt Noll
 ##
 ## Calc is open software; you can redistribute it and/or modify it under


### PR DESCRIPTION
This contribution informs the user of the idiomatic way to have their calc set-up adhere to the XDG Base Directory specification, which aims to consolidate where various tools would be best located semantically for a more unified user experience in catering to their tools.

Ref: https://specifications.freedesktop.org/basedir/latest/
Ref: https://github.com/lcn2/calc/issues/195