### PR TITLE
Introduce XDG base directories built-in support in calc v3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,12 @@ The following are the changes from calc version 3.0.0.3 to date:
     Use `${EXPAND}` to replace ASCII tabs with ASCII spaces in the
     `make len_bits.h` rule, and the `make errsym.h` rule of `Makefile`.
 
+    Add support for the XDG Base Directory specification:
+
+        https://specifications.freedesktop.org/basedir/latest/
+
+    Thanks to GitHub user @ccjmne for helping add this support.
+
 
 The following are the changes from calc version 3.0.0.2 to 3.0.0.3:
 

--- a/Makefile
+++ b/Makefile
@@ -617,10 +617,20 @@ conf.h: ${MK_SET}
 	${Q} echo '#define DEFAULTCALCPATH "${CALCPATH}"' >> $@
 	${Q} echo '#endif /* DEFAULTCALCPATH */' >> $@
 	${Q} echo '' >> $@
+	${Q} echo '/* the default system search path */' >> $@
+	${Q} echo '#if !defined(DEFAULTCALCPATH_SYS)' >> $@
+	${Q} echo '#define DEFAULTCALCPATH_SYS "${T}${CALC_SHAREDIR}:${T}${CUSTOMCALDIR}"' >> $@
+	${Q} echo '#endif /* DEFAULTCALCPATH_SYS */' >> $@
+	${Q} echo '' >> $@
 	${Q} echo '/* the default :-separated startup file list */' >> $@
 	${Q} echo '#if !defined(DEFAULTCALCRC)' >> $@
 	${Q} echo '#define DEFAULTCALCRC "${CALCRC}"' >> $@
 	${Q} echo '#endif /* DEFAULTCALCRC */' >> $@
+	${Q} echo '' >> $@
+	${Q} echo '/* the default system startup file */' >> $@
+	${Q} echo '#if !defined(DEFAULTCALCRC_SYS)' >> $@
+	${Q} echo '#define DEFAULTCALCRC_SYS "${T}${CALC_SHAREDIR}/startup"' >> $@
+	${Q} echo '#endif /* DEFAULTCALCRC_SYS */' >> $@
 	${Q} echo '' >> $@
 	${Q} echo '/* the location of the help directory */' >> $@
 	${Q} echo '#if !defined(HELPDIR)' >> $@

--- a/Makefile
+++ b/Makefile
@@ -3482,6 +3482,7 @@ lib_calc.o: hash.h
 lib_calc.o: have_ban_pragma.h
 lib_calc.o: have_strlcat.h
 lib_calc.o: have_strlcpy.h
+lib_calc.o: have_unused.h
 lib_calc.o: int.h
 lib_calc.o: label.h
 lib_calc.o: len_bits.h

--- a/Makefile
+++ b/Makefile
@@ -1804,6 +1804,8 @@ env:
 	@echo 'WNO_IMPLICT=${WNO_IMPLICT};' echo ''
 	@echo 'WNO_LONG_LONG=${WNO_LONG_LONG}'; echo ''
 	@echo 'XARGS=${XARGS}'; echo ''
+	@echo 'XDG_CONFIG_HOME=${XDG_CONFIG_HOME}'; echo ''
+	@echo 'XDG_DATA_HOME=${XDG_DATA_HOME}'; echo ''
 	@echo 'arch=${arch}'; echo ''
 	@echo 'hardware=${hardware}'; echo ''
 	@echo 'target=${target}'; echo ''

--- a/README.md
+++ b/README.md
@@ -288,17 +288,11 @@ that may surprise C programmers.  The command:
 help environment
 ```
 
-contains information regarding how environment variables
-can be used to configure some aspects of calc.  In versions
-prior to v3, you may adhere to the [XDG Base Directory
-specification](https://specifications.freedesktop.org/basedir/latest/)
-by setting up your environment variables as such:
-
-```sh
-export CALCRC="${XDG_CONFIG_HOME:-$HOME/.config}/calc/calcrc"
-export CALCPATH=".:${XDG_DATA_HOME:-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
-export CALCHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/calc/history"
-```
+contains information regarding how environment variables can be
+used to configure some aspects of calc.  In calc v3, if `CALCRC`,
+`CALCPATH`, and `CALCHISTFILE` are unset, calc first checks the
+relevant XDG base directory environment variables and uses them when
+they name usable absolute directories.
 
 Note that calc won't create the directory tree to `$CALCHISTFILE`,
 you'll need to run:

--- a/README.md
+++ b/README.md
@@ -294,16 +294,6 @@ used to configure some aspects of calc.  In calc v3, if `CALCRC`,
 relevant XDG base directory environment variables and uses them when
 they name usable absolute directories.
 
-Note that calc won't create the directory tree to `$CALCHISTFILE`,
-you'll need to run:
-
-```sh
-mkdir -p $(dirname $CALCHISTFILE)
-```
-
-in order to have the history mechanism if you choose a path to a file
-that doesn't exist.
-
 # Reporting Security Issues
 
 To report a security issue, please visit "[Reporting Security Issues](https://github.com/lcn2/calc/security/policy)".

--- a/README.md
+++ b/README.md
@@ -289,10 +289,13 @@ help environment
 ```
 
 contains information regarding how environment variables can be
-used to configure some aspects of calc.  If `CALCRC`,
-`CALCPATH`, and `CALCHISTFILE` are unset, calc first checks the
-relevant XDG base directory environment variables and uses them when
-they name usable absolute directories.
+used to configure some aspects of calc.  If `CALCRC` and
+`CALCPATH` are unset, calc first checks the relevant XDG base
+directory environment variables and uses them when they name
+usable absolute directories.  If `CALCHISTFILE` is unset,
+calc preserves an existing `~/.calc_history`; otherwise it uses
+`${XDG_STATE_HOME}/calc/history` when `XDG_STATE_HOME` names a
+usable absolute writable directory.
 
 # Reporting Security Issues
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ help environment
 ```
 
 contains information regarding how environment variables can be
-used to configure some aspects of calc.  In calc v3, if `CALCRC`,
+used to configure some aspects of calc.  If `CALCRC`,
 `CALCPATH`, and `CALCHISTFILE` are unset, calc first checks the
 relevant XDG base directory environment variables and uses them when
 they name usable absolute directories.

--- a/calc.man
+++ b/calc.man
@@ -1201,9 +1201,36 @@ A :-separated list of directories used to search for calc
 resource filenames that do not begin with /, ./ or ~.
 .br
 .sp
-Default value: ${CALCPATH}
-.br
-.sp
+If this variable is unset or empty,
+.B calc
+first checks $XDG_DATA_HOME and $XDG_CONFIG_HOME.
+When both name usable absolute directories,
+.B calc
+searches in succession:
+.sp 1
+.in +5n
+.nf
+.
+./cal
+${XDG_DATA_HOME}/calc
+${XDG_CONFIG_HOME}/calc
+${CALC_SHAREDIR}
+${CUSTOMCALDIR}
+.fi
+.in -5n
+.sp 1
+If neither XDG directory is usable, the compiled fallback is usually:
+.sp 1
+.in +5n
+.nf
+.
+./cal
+~/.cal
+${CALC_SHAREDIR}
+${CUSTOMCALDIR}
+.fi
+.in -5n
+.sp 1
 .TP 5
 CALCRC
 On startup (unless \-h or \-q was given on the command
@@ -1213,9 +1240,31 @@ searches for files along this :-separated
 environment variable.
 .br
 .sp
-Default value: ${CALCRC}
-.br
-.sp
+If this variable is unset or empty,
+.B calc
+first checks $XDG_CONFIG_HOME.
+When it names a usable absolute directory,
+.B calc
+searches in succession:
+.sp 1
+.in +5n
+.nf
+./.calcinit
+${XDG_CONFIG_HOME}/calc/calcrc
+${CALC_SHAREDIR}/startup
+.fi
+.in -5n
+.sp 1
+If $XDG_CONFIG_HOME is not usable, the compiled fallback is usually:
+.sp 1
+.in +5n
+.nf
+./.calcinit
+~/.calcrc
+${CALC_SHAREDIR}/startup
+.fi
+.in -5n
+.sp 1
 .TP 5
 CALCBINDINGS
 On startup (unless \fI\-h\fP or \fI\-q\fP was given on the command
@@ -1236,8 +1285,26 @@ In that case, the standard readline mechanisms (see readline(3)) are used.
 CALCHISTFILE
 Location of the calc history file.
 .sp
-Default value: ~/.calc_history
-.sp
+If this variable is unset or empty,
+.B calc
+first checks $XDG_STATE_HOME.
+When it names a usable absolute writable directory,
+the effective value is:
+.sp 1
+.in +5n
+.nf
+${XDG_STATE_HOME}/calc/history
+.fi
+.in -5n
+.sp 1
+If $XDG_STATE_HOME is not usable, the fallback value is:
+.sp 1
+.in +5n
+.nf
+~/.calc_history
+.fi
+.in -5n
+.sp 1
 This variable is not used if calc was compiled with GNU-readline support.
 .sp
 .TP 5
@@ -1255,21 +1322,26 @@ Default value: ${CUSTOMHELPDIR}
 
 .PP
 
-In versions prior to v3, you may adhere to the XDG Base Directory
-specification by setting up your environment variables as such:
+When CALCPATH, CALCRC and CALCHISTFILE are unset or empty,
+.B calc
+follows the XDG Base Directory Specification as described above.
+.sp
+You may override those locations by setting the calc
+environment variables explicitly.  For example, to restore
+the usual legacy defaults on a typical Unix install:
 .sp
 .in +5n
 .nf
-export CALCRC="${XDG_CONFIG_HOME:\-$HOME/.config}/calc/calcrc"
-export CALCPATH=".:${XDG_DATA_HOME:\-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:\-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
-export CALCHISTFILE="${XDG_STATE_HOME:\-$HOME/.local/state}/calc/history"
+export CALCRC="./.calcinit:$HOME/.calcrc:/usr/share/calc/startup"
+export CALCPATH=".:./cal:$HOME/.cal:/usr/share/calc:/usr/share/calc/custom"
+export CALCHISTFILE="$HOME/.calc_history"
 .fi
 .in -5n
 .sp
 Note that
 .B calc
-won't create the directory tree to $CALCHISTFILE,
-you'll need to run:
+will attempt to create the parent directory of $CALCHISTFILE.
+If that is not sufficient, you may need to run:
 .sp
 .in +5n
 .nf
@@ -1277,8 +1349,8 @@ mkdir \-p $(dirname $CALCHISTFILE)
 .fi
 .in -5n
 .sp
-in order to have the history mechanism if you choose a path to a file
-that doesn't exist.
+for the history mechanism if you choose a path to a file that
+does not yet exist.
 .sp
 
 .SH CREDIT

--- a/calc.man
+++ b/calc.man
@@ -1287,7 +1287,12 @@ Location of the calc history file.
 .sp
 If this variable is unset or empty,
 .B calc
-first checks $XDG_STATE_HOME.
+first uses an existing
+.B ~/.calc_history
+file.
+Otherwise,
+.B calc
+checks $XDG_STATE_HOME.
 When it names a usable absolute writable directory,
 the effective value is:
 .sp 1
@@ -1297,7 +1302,7 @@ ${XDG_STATE_HOME}/calc/history
 .fi
 .in -5n
 .sp 1
-If $XDG_STATE_HOME is not usable, the fallback value is:
+If neither applies, the fallback value is:
 .sp 1
 .in +5n
 .nf

--- a/calc.man
+++ b/calc.man
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (C) 1999-2007,2014,2018,2021      Landon Curt Noll
+.\" Copyright (C) 1999-2007,2014,2018,2021,2026      Landon Curt Noll
 .\"
 .\" Calc is open software; you can redistribute it and/or modify it under
 .\" the terms of the version 2.1 of the GNU Lesser General Public License
@@ -1342,6 +1342,14 @@ export CALCPATH=".:./cal:$HOME/.cal:/usr/share/calc:/usr/share/calc/custom"
 export CALCHISTFILE="$HOME/.calc_history"
 .fi
 .in -5n
+.sp
+For more information on the XDG Base Directory specification see:
+.sp
+.in +0.5i
+.nf
+https://specifications.freedesktop.org/basedir/latest/
+.fi
+.in -0.5i
 .sp
 Note that
 .B calc

--- a/help/environment
+++ b/help/environment
@@ -8,12 +8,13 @@ Environment variables
                 /       ./      ../     ~
 
         If this variable does not exist, or if this
-        variable is an empty string, a compiled value
-        is used.  Typically compiled in value is:
+        variable is an empty string, calc first checks
+        $XDG_DATA_HOME and $XDG_CONFIG_HOME.  When both
+        name usable absolute directories, calc uses:
 
-                    .:./cal:~/cal:${CALC_SHAREDIR}:${CUSTOMCALDIR}
+                    .:./cal:$XDG_DATA_HOME/calc:$XDG_CONFIG_HOME/calc:${CALC_SHAREDIR}:${CUSTOMCALDIR}
 
-        which is usually:
+        Otherwise a compiled value is used, which is usually:
 
                     .:./cal:~/cal:/usr/share/calc:/usr/share/calc/custom
 
@@ -29,12 +30,13 @@ Environment variables
         $CALCRC environment variable.
 
         If this variable does not exist, or if this
-        variable is an empty string, a compiled value
-        is used.  Typically compiled in value is:
+        variable is an empty string, calc first checks
+        $XDG_CONFIG_HOME.  When it names a usable absolute
+        directory, calc uses:
 
-                    ${CALC_SHAREDIR}/startup:~/.calcrc:./.calcinit
+                    ./.calcinit:$XDG_CONFIG_HOME/calc/calcrc:${CALC_SHAREDIR}/startup
 
-        which is usually:
+        Otherwise a compiled value is used, which is usually:
 
                     /usr/share/calc/startup:~/.calcrc:./.calcinit
 
@@ -98,8 +100,10 @@ Environment variables
         This value is taken to be the calc history file.
 
         If this variable does not exist, or if this
-        variable is an empty string, then ~/.calc_history
-        is used.
+        variable is an empty string, calc first checks
+        $XDG_STATE_HOME and uses $XDG_STATE_HOME/calc/history
+        when that names a usable absolute directory.
+        Otherwise ~/.calc_history is used.
 
      CALCHELP
 
@@ -116,8 +120,8 @@ Environment variables
         variable is an empty string, then ${CUSTOMHELPDIR}
         is used.
 
-In versions prior to v3, you may adhere to the XDG Base Directory
-specification by setting up your environment variables as such:
+You may still force explicit locations by setting the calc
+environment variables as such:
 
         export CALCRC="${XDG_CONFIG_HOME:-$HOME/.config}/calc/calcrc"
         export CALCPATH=".:${XDG_DATA_HOME:-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"

--- a/help/environment
+++ b/help/environment
@@ -114,10 +114,11 @@ Environment variables
         This value is taken to be the calc history file.
 
         If this variable does not exist, or if this
-        variable is an empty string, calc first checks
+        variable is an empty string, calc first uses an
+        existing ~/.calc_history file.  Otherwise calc checks
         $XDG_STATE_HOME and uses ${XDG_STATE_HOME}/calc/history
         when that names a usable absolute writable directory.
-        Otherwise ~/.calc_history is used.
+        If neither applies, ~/.calc_history is used.
 
      CALCHELP
 

--- a/help/environment
+++ b/help/environment
@@ -10,13 +10,23 @@ Environment variables
         If this variable does not exist, or if this
         variable is an empty string, calc first checks
         $XDG_DATA_HOME and $XDG_CONFIG_HOME.  When both
-        name usable absolute directories, calc uses:
+        name usable absolute directories, calc searches in
+        succession:
 
-                    .:./cal:${XDG_DATA_HOME}/calc:${XDG_CONFIG_HOME}/calc:${CALC_SHAREDIR}:${CUSTOMCALDIR}
+                    .
+                    ./cal
+                    ${XDG_DATA_HOME}/calc
+                    ${XDG_CONFIG_HOME}/calc
+                    ${CALC_SHAREDIR}
+                    ${CUSTOMCALDIR}
 
         Otherwise a compiled value is used, which is usually:
 
-                    .:./cal:~/cal:/usr/share/calc:/usr/share/calc/custom
+                    .
+                    ./cal
+                    ~/.cal
+                    /usr/share/calc
+                    /usr/share/calc/custom
 
         This value is used by the READ command.  It is an error
         if no such readable file is found.
@@ -32,13 +42,17 @@ Environment variables
         If this variable does not exist, or if this
         variable is an empty string, calc first checks
         $XDG_CONFIG_HOME.  When it names a usable absolute
-        directory, calc uses:
+        directory, calc searches in succession:
 
-                    ./.calcinit:${XDG_CONFIG_HOME}/calc/calcrc:${CALC_SHAREDIR}/startup
+                    ./.calcinit
+                    ${XDG_CONFIG_HOME}/calc/calcrc
+                    ${CALC_SHAREDIR}/startup
 
         Otherwise a compiled value is used, which is usually:
 
-                    /usr/share/calc/startup:~/.calcrc:./.calcinit
+                    ./.calcinit
+                    ~/.calcrc
+                    /usr/share/calc/startup
 
         Missing files along the $CALCRC path are silently ignored.
 
@@ -102,7 +116,7 @@ Environment variables
         If this variable does not exist, or if this
         variable is an empty string, calc first checks
         $XDG_STATE_HOME and uses ${XDG_STATE_HOME}/calc/history
-        when that names a usable absolute directory.
+        when that names a usable absolute writable directory.
         Otherwise ~/.calc_history is used.
 
      CALCHELP
@@ -120,20 +134,24 @@ Environment variables
         variable is an empty string, then ${CUSTOMHELPDIR}
         is used.
 
-You may still force explicit locations by setting the calc
-environment variables as such:
+When CALCPATH, CALCRC and CALCHISTFILE are unset or empty,
+calc follows the XDG Base Directory Specification as described above.
 
-        export CALCRC="${XDG_CONFIG_HOME:-$HOME/.config}/calc/calcrc"
-        export CALCPATH=".:${XDG_DATA_HOME:-$HOME/.local/share}/calc:${XDG_CONFIG_HOME:-$HOME/.config}/calc:/usr/share/calc:/usr/share/calc/custom"
-        export CALCHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/calc/history"
+You may override those locations by setting the calc
+environment variables explicitly.  For example, to restore
+the usual legacy defaults on a typical Unix install:
 
-Note that calc won't create the directory tree to $CALCHISTFILE,
-you'll need to run:
+        export CALCRC="./.calcinit:$HOME/.calcrc:/usr/share/calc/startup"
+        export CALCPATH=".:./cal:$HOME/.cal:/usr/share/calc:/usr/share/calc/custom"
+        export CALCHISTFILE="$HOME/.calc_history"
+
+Note that calc will attempt to create the parent directory of
+$CALCHISTFILE.  If that is not sufficient, you may need to run:
 
         mkdir -p $(dirname $CALCHISTFILE)
 
-in order to have the history mechanism if you choose a path to a file
-that doesn't exist.
+for the history mechanism if you choose a path to a file that
+does not yet exist.
 
 ## Copyright (C) 1999,2021,2026  Landon Curt Noll
 ##

--- a/help/environment
+++ b/help/environment
@@ -12,7 +12,7 @@ Environment variables
         $XDG_DATA_HOME and $XDG_CONFIG_HOME.  When both
         name usable absolute directories, calc uses:
 
-                    .:./cal:$XDG_DATA_HOME/calc:$XDG_CONFIG_HOME/calc:${CALC_SHAREDIR}:${CUSTOMCALDIR}
+                    .:./cal:${XDG_DATA_HOME}/calc:${XDG_CONFIG_HOME}/calc:${CALC_SHAREDIR}:${CUSTOMCALDIR}
 
         Otherwise a compiled value is used, which is usually:
 
@@ -34,7 +34,7 @@ Environment variables
         $XDG_CONFIG_HOME.  When it names a usable absolute
         directory, calc uses:
 
-                    ./.calcinit:$XDG_CONFIG_HOME/calc/calcrc:${CALC_SHAREDIR}/startup
+                    ./.calcinit:${XDG_CONFIG_HOME}/calc/calcrc:${CALC_SHAREDIR}/startup
 
         Otherwise a compiled value is used, which is usually:
 
@@ -101,7 +101,7 @@ Environment variables
 
         If this variable does not exist, or if this
         variable is an empty string, calc first checks
-        $XDG_STATE_HOME and uses $XDG_STATE_HOME/calc/history
+        $XDG_STATE_HOME and uses ${XDG_STATE_HOME}/calc/history
         when that names a usable absolute directory.
         Otherwise ~/.calc_history is used.
 
@@ -135,7 +135,7 @@ you'll need to run:
 in order to have the history mechanism if you choose a path to a file
 that doesn't exist.
 
-## Copyright (C) 1999,2021  Landon Curt Noll
+## Copyright (C) 1999,2021,2026  Landon Curt Noll
 ##
 ## Calc is open software; you can redistribute it and/or modify it under
 ## the terms of the version 2.1 of the GNU Lesser General Public License

--- a/hist.c
+++ b/hist.c
@@ -44,6 +44,7 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/stat.h>
 
 /*
  * conditional <system> head includes
@@ -1486,6 +1487,34 @@ quit_calc(int UNUSED(ch))
 #  include <readline/readline.h>
 #  include <readline/history.h>
 
+static void
+hist_mkdir_parent(void)
+{
+    char *dir;
+    char *slash;
+
+    if (calc_history == NULL) {
+        return;
+    }
+
+    slash = strrchr(calc_history, PATHCHAR);
+    if (slash == NULL || slash == calc_history) {
+        return;
+    }
+
+    dir = strdup(calc_history);
+    if (dir == NULL) {
+        return;
+    }
+    dir[slash - calc_history] = '\0';
+
+    if (access(dir, F_OK) != 0) {
+        (void)mkdir(dir, 0700);
+    }
+
+    free(dir);
+}
+
 /*
  * The readline/history libs do most of the dirty work for us, so we can
  * replace hist_init() and hist_term() with dummies when using readline.
@@ -1611,6 +1640,9 @@ hist_init(char *UNUSED(filename))
     if (calc_history == NULL) {
         return HIST_NULL_HIST;
     }
+
+    /* create parent directory if necessary */
+    hist_mkdir_parent();
 
     /* read previous history */
     read_history(calc_history);

--- a/hist.c
+++ b/hist.c
@@ -132,6 +132,7 @@ static void lowercase_word(int key);
 static void ignore_char(int key);
 static void arrow_key(int key);
 static void quit_calc(int key) __attribute__((noreturn));
+static void hist_mkdir_parent(void);
 
 static FUNC funcs[] = {{"ignore-char", ignore_char},
                        {"flush-input", flush_input},

--- a/lib_calc.c
+++ b/lib_calc.c
@@ -171,6 +171,7 @@ static ttystruct *fd_cur = NULL;   /* fd current state */
 static void initenv(void);         /* setup calc environment */
 static int find_tty_state(int fd); /* find slot for saved tty state */
 static bool initialized = false;   /* true => initialize() has been run */
+static char *xdg_base(char *env, int mode);
 
 /*
  * libcalc_call_me_first - users of libcalc.a must call this function first!
@@ -433,8 +434,9 @@ cvmalloc_error(char *message)
 /*
  * initenv - obtain various environment variable values.
  *
- * If these environment variables do not exist, or is an empty string,
- * use the default values as found in calc.h:
+ * If these environment variables do not exist, or if they are an empty string,
+ * use XDG defaults when the relevant XDG directory is usable, otherwise use
+ * the compiled default values as found in calc.h:
  *
  *      $CALCPATH               set calcpath
  *      $CALCRC                 set calcrc
@@ -468,11 +470,24 @@ initenv(void)
     struct passwd *ent; /* our password entry */
 #endif
     char *c;
+    char *xdg_config;
+    char *xdg_data;
+    size_t len;
 
     /* determine the $CALCPATH value */
     c = (no_env ? NULL : getenv(CALCPATH));
-    calcpath = (c ? strdup(c) : NULL);
-    if (calcpath == NULL || *calcpath == '\0') {
+    if (c != NULL && *c != '\0') {
+        calcpath = strdup(c);
+    } else if ((xdg_data = xdg_base("XDG_DATA_HOME", X_OK)) != NULL &&
+               (xdg_config = xdg_base("XDG_CONFIG_HOME", X_OK)) != NULL) {
+        len = strlen(xdg_data) + strlen(xdg_config) + sizeof(".:./cal:/calc:/calc:") + strlen(DEFAULTCALCPATH_SYS);
+        calcpath = malloc(len);
+        if (calcpath == NULL) {
+            math_error("Unable to allocate string for calcpath");
+            not_reached();
+        }
+        snprintf(calcpath, len, ".:./cal:%s/calc:%s/calc:%s", xdg_data, xdg_config, DEFAULTCALCPATH_SYS);
+    } else {
         calcpath = strdup(DEFAULTCALCPATH);
     }
     if (calcpath == NULL) {
@@ -482,8 +497,17 @@ initenv(void)
 
     /* determine the $CALCRC value */
     c = (no_env ? NULL : getenv(CALCRC));
-    calcrc = (c ? strdup(c) : NULL);
-    if (calcrc == NULL || *calcrc == '\0') {
+    if (c != NULL && *c != '\0') {
+        calcrc = strdup(c);
+    } else if ((xdg_config = xdg_base("XDG_CONFIG_HOME", X_OK)) != NULL) {
+        len = strlen(xdg_config) + sizeof("./.calcinit:/calc/calcrc:") + strlen(DEFAULTCALCRC_SYS);
+        calcrc = malloc(len);
+        if (calcrc == NULL) {
+            math_error("Unable to allocate string for calcrc");
+            not_reached();
+        }
+        snprintf(calcrc, len, "./.calcinit:%s/calc/calcrc:%s", xdg_config, DEFAULTCALCRC_SYS);
+    } else {
         calcrc = strdup(DEFAULTCALCRC);
     }
     if (calcrc == NULL) {
@@ -570,9 +594,16 @@ initenv(void)
 
     /* determine the $CALCHISTFILE value */
     c = (no_env ? NULL : getenv(CALCHISTFILE));
-    calc_history = (c ? strdup(c) : NULL);
-    if (calc_history == NULL || *calc_history == '\0') {
-        calc_history = NULL; /* will use ~/.calc_history */
+    if (c != NULL && *c != '\0') {
+        calc_history = strdup(c);
+    } else if ((c = xdg_base("XDG_STATE_HOME", X_OK | W_OK)) != NULL) {
+        len = strlen(c) + sizeof("/calc/history");
+        calc_history = malloc(len);
+        if (calc_history == NULL) {
+            math_error("Unable to allocate string for calc_history");
+            not_reached();
+        }
+        snprintf(calc_history, len, "%s/calc/history", c);
     }
     /* NOTE: calc_history may be set to NULL in which case hist_init() may set it later on */
 
@@ -1022,4 +1053,19 @@ orig_tty(int fd)
      */
     fd_setup[slot] = -1;
     return true;
+}
+
+/*
+ * xdg_base - return an XDG base directory if it names a usable absolute path.
+ */
+static char *
+xdg_base(char *env, int mode)
+{
+    char *base;
+
+    base = (no_env ? NULL : getenv(env));
+    if (base == NULL || *base == '\0' || base[0] != PATHCHAR || access(base, mode) != 0) {
+        return NULL;
+    }
+    return base;
 }

--- a/lib_calc.c
+++ b/lib_calc.c
@@ -59,6 +59,7 @@ typedef struct termios ttystruct;
 #include "label.h"
 #include "func.h"
 #include "strl.h"
+#include "have_unused.h"
 #if defined(CUSTOM)
 #  include "custom.h"
 #endif
@@ -1058,6 +1059,17 @@ orig_tty(int fd)
 /*
  * xdg_base - return an XDG base directory if it names a usable absolute path.
  */
+#if defined(_WIN32) || defined(_WIN64)
+
+static char *
+xdg_base(char *UNUSED(env), int UNUSED(mode))
+{
+    return NULL;
+
+}
+
+#else
+
 static char *
 xdg_base(char *env, int mode)
 {
@@ -1069,3 +1081,5 @@ xdg_base(char *env, int mode)
     }
     return base;
 }
+
+#endif

--- a/lib_calc.c
+++ b/lib_calc.c
@@ -437,7 +437,8 @@ cvmalloc_error(char *message)
  *
  * If these environment variables do not exist, or if they are an empty string,
  * use XDG defaults when the relevant XDG directory is usable, otherwise use
- * the compiled default values as found in calc.h:
+ * the compiled default values as found in calc.h.  For calc_history, favour
+ * preserving an existing ~/.calc_history over using the XDG state directory:
  *
  *      $CALCPATH               set calcpath
  *      $CALCRC                 set calcrc
@@ -471,6 +472,7 @@ initenv(void)
     struct passwd *ent; /* our password entry */
 #endif
     char *c;
+    char *legacy_history;
     char *xdg_config;
     char *xdg_data;
     size_t len;
@@ -597,7 +599,21 @@ initenv(void)
     c = (no_env ? NULL : getenv(CALCHISTFILE));
     if (c != NULL && *c != '\0') {
         calc_history = strdup(c);
-    } else if ((c = xdg_base("XDG_STATE_HOME", X_OK | W_OK)) != NULL) {
+    } else if (home != NULL) {
+        len = strlen(home) + sizeof("/.calc_history");
+        legacy_history = malloc(len);
+        if (legacy_history == NULL) {
+            math_error("Unable to allocate string for legacy_history");
+            not_reached();
+        }
+        snprintf(legacy_history, len, "%s/.calc_history", home);
+        if (access(legacy_history, F_OK) == 0) {
+            calc_history = legacy_history;
+        } else {
+            free(legacy_history);
+        }
+    }
+    if (calc_history == NULL && (c = xdg_base("XDG_STATE_HOME", X_OK | W_OK)) != NULL) {
         len = strlen(c) + sizeof("/calc/history");
         calc_history = malloc(len);
         if (calc_history == NULL) {


### PR DESCRIPTION
As discussed in #195, I propose here to adhere to the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir/latest/) if the user has adequately set the corresponding variables.

## TL;DR:

In this implementation, the `XDG_XXX` environment variables are used to derive the `CALCPATH`, `CALCRC`, and `CALCHISTFILE` when:
- these calc-specific variables are unset, and
- the XDG paths are usable

## Windows

I read up a bit on the topic of support for Windows and it seems that the problem isn't all that easy, considering that `%APPDATA%` and other directories seem to be well-established there. I'm frankly quite like a fish out of water when it comes to Windows, and figured I would simply disregard anything XDG on that platform, see 0ffa8aac613ebd5295d74a948ff7ba2941d89820.

We may just choose to not pull in that specific commit: I suppose that if some Windows users have set up all their XDG variables, they likely do want them to be used... I merely am not confident enough with that platform to make any semblance of educated guess.

## History file

I took the liberty of automatically creating the directory structure that will point to the history file, so as to preserve the out-of-the-box experience that's well-established with calc, where the history is preserved between sessions; see 0af5e3a14accdb6facd2fe59258d6b7492f77309.

The crucial point here is that where the previous default `~/.calc_history` would always point to a directory that exists, the user's home; the new `$XDG_STATE_HOME/calc/history` would certainly not.

This file is the only one that calc needs to create itself and would result in degraded functionality without some extra set-up from the user: I believe that this basis being covered covers all the bases that need covering :-)

## Testing

A quick test I used for myself was essentially as follows:

```sh
mkdir -p /tmp/calc-xdg/{config,data,state}
env -u CALCPATH                          \
    -u CALCRC                            \
    -u CALCHISTFILE                      \
    XDG_CONFIG_HOME=/tmp/calc-xdg/config \
    XDG_DATA_HOME=/tmp/calc-xdg/data     \
    XDG_STATE_HOME=/tmp/calc-xdg/state   \
    ./calc -q 'calcpath()'
```

I don't recommend that simply running the test be a sufficient validation, I'm only offering some bit that I found was handy for exploration :-)

### Disclaimer

I tried pretty hard to adhere to the style of the code base, but my C is very rusty and was never to a professional level in the first place.

I'm truly grateful that I get to contribute, and would have no problem changing anything: don't hesitate to share any concern or preference you may have, I would love to know better.