### PR TITLE
update README with Arch Linux pacman installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 ```
 misc linux: sudo yum install calc
+on Arch:    sudo pacman -S calc
 on Debian:  sudo apt install calc
 on RHEL:    sudo dnf install calc
 on Ubuntu:  sudo apt install calc


### PR DESCRIPTION
Calc is available in the Arch Linux [extra repository](https://archlinux.org/packages/extra/x86_64/calc/), so README installation instructions now mention pacman.

Alphabetical ordering in the distro list was preserved.